### PR TITLE
feat: Add opt-in programmatic init API for first-boot setup

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -3,10 +3,10 @@ import os
 import sys
 import time
 import weakref
-from distutils.version import StrictVersion
 
 import jinja2
 from flask import Flask, Request
+from packaging.version import Version
 from flask_babel import Babel
 from flask_migrate import upgrade
 from jinja2 import FileSystemLoader
@@ -288,7 +288,7 @@ def create_app(config="CTFd.config.Config"):
         version = utils.get_config("ctf_version")
 
         # Upgrading from an older version of CTFd
-        if version and (StrictVersion(version) < StrictVersion(__version__)):
+        if version and (Version(version) < Version(__version__)):
             if confirm_upgrade():
                 run_upgrade()
             else:

--- a/CTFd/api/__init__.py
+++ b/CTFd/api/__init__.py
@@ -28,6 +28,7 @@ from CTFd.api.v1.tokens import tokens_namespace
 from CTFd.api.v1.topics import topics_namespace
 from CTFd.api.v1.unlocks import unlocks_namespace
 from CTFd.api.v1.users import users_namespace
+from CTFd.api.v1.init import init_namespace
 
 api = Blueprint("api", __name__, url_prefix="/api/v1")
 CTFd_API_v1 = Api(
@@ -73,3 +74,4 @@ CTFd_API_v1.add_namespace(shares_namespace, "/shares")
 CTFd_API_v1.add_namespace(brackets_namespace, "/brackets")
 CTFd_API_v1.add_namespace(exports_namespace, "/exports")
 CTFd_API_v1.add_namespace(solutions_namespace, "/solutions")
+CTFd_API_v1.add_namespace(init_namespace, "/init")

--- a/CTFd/api/v1/init.py
+++ b/CTFd/api/v1/init.py
@@ -1,0 +1,69 @@
+from flask import request, current_app
+from flask_restx import Namespace, Resource
+
+from CTFd.utils.config import is_setup
+from CTFd.utils.initialization import setup_ctf
+from CTFd.models import Users
+from CTFd.utils import validators
+
+init_namespace = Namespace("init", description="Endpoint to initialize CTFd")
+
+
+@init_namespace.route("/setup", methods=["POST"])
+class Setup(Resource):
+    def post(self):
+        if not current_app.config.get("INIT_API_ENABLED"):
+            return {"success": False, "message": "API is not enabled"}, 403
+
+        token = request.headers.get("Authorization", "").split(" ")[-1]
+        if not token == current_app.config.get("INIT_API_TOKEN"):
+            return {"success": False, "message": "Invalid token"}, 401
+
+        if is_setup():
+            return {"success": False, "message": "Already configured"}, 409
+
+        data = request.get_json()
+
+        errors = []
+        # Administration
+        name = data.get("name", "").strip()
+        email = data.get("email", "").strip()
+        password = data.get("password", "").strip()
+
+        name_len = len(name) == 0
+        names = (
+            Users.query.add_columns(Users.name, Users.id)
+            .filter_by(name=name)
+            .first()
+        )
+        emails = (
+            Users.query.add_columns(Users.email, Users.id)
+            .filter_by(email=email)
+            .first()
+        )
+        pass_short = len(password) == 0
+        pass_long = len(password) > 128
+        valid_email = validators.validate_email(email)
+        team_name_email_check = validators.validate_email(name)
+
+        if not valid_email:
+            errors.append("Please enter a valid email address")
+        if names:
+            errors.append("That user name is already taken")
+        if team_name_email_check is True:
+            errors.append("Your user name cannot be an email address")
+        if emails:
+            errors.append("That email has already been used")
+        if pass_short:
+            errors.append("Pick a longer password")
+        if pass_long:
+            errors.append("Pick a shorter password")
+        if name_len:
+            errors.append("Pick a longer user name")
+
+        if len(errors) > 0:
+            return {"success": False, "errors": errors}, 400
+
+        setup_ctf(args=data)
+
+        return {"success": True}

--- a/CTFd/api/v1/init.py
+++ b/CTFd/api/v1/init.py
@@ -5,7 +5,7 @@ from flask_restx import Namespace, Resource
 from CTFd.utils.config import is_setup
 from CTFd.utils.initialization import setup_ctf
 from CTFd.models import Users
-from CTFd.utils import validators
+from CTFd.utils.validators.users import validate_admin_user
 
 init_namespace = Namespace("init", description="Endpoint to initialize CTFd")
 
@@ -30,42 +30,11 @@ class Setup(Resource):
 
         data = request.get_json()
 
-        errors = []
-        # Administration
-        name = data.get("name", "").strip()
-        email = data.get("email", "").strip()
-        password = data.get("password", "").strip()
-
-        name_len = len(name) == 0
-        names = (
-            Users.query.add_columns(Users.name, Users.id)
-            .filter_by(name=name)
-            .first()
+        errors = validate_admin_user(
+            name=data.get("name"),
+            email=data.get("email"),
+            password=data.get("password"),
         )
-        emails = (
-            Users.query.add_columns(Users.email, Users.id)
-            .filter_by(email=email)
-            .first()
-        )
-        pass_short = len(password) == 0
-        pass_long = len(password) > 128
-        valid_email = validators.validate_email(email)
-        team_name_email_check = validators.validate_email(name)
-
-        if not valid_email:
-            errors.append("Please enter a valid email address")
-        if names:
-            errors.append("That user name is already taken")
-        if team_name_email_check is True:
-            errors.append("Your user name cannot be an email address")
-        if emails:
-            errors.append("That email has already been used")
-        if pass_short:
-            errors.append("Pick a longer password")
-        if pass_long:
-            errors.append("Pick a shorter password")
-        if name_len:
-            errors.append("Pick a longer user name")
 
         if len(errors) > 0:
             return {"success": False, "errors": errors}, 400

--- a/CTFd/api/v1/init.py
+++ b/CTFd/api/v1/init.py
@@ -1,3 +1,4 @@
+import secrets
 from flask import request, current_app
 from flask_restx import Namespace, Resource
 
@@ -15,8 +16,13 @@ class Setup(Resource):
         if not current_app.config.get("INIT_API_ENABLED"):
             return {"success": False, "message": "API is not enabled"}, 403
 
-        token = request.headers.get("Authorization", "").split(" ")[-1]
-        if not token == current_app.config.get("INIT_API_TOKEN"):
+        auth_header = request.headers.get("Authorization", "")
+        parts = auth_header.split()
+        if len(parts) != 2 or parts[0] != "Bearer":
+            return {"success": False, "message": "Invalid token format"}, 401
+        token = parts[1]
+
+        if not secrets.compare_digest(token, current_app.config.get("INIT_API_TOKEN", "")):
             return {"success": False, "message": "Invalid token"}, 401
 
         if is_setup():

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -96,6 +96,17 @@ REDIS_PORT =
 # The index of the Redis database to access, if `REDIS_HOST` is set.
 REDIS_DB =
 
+
+[init]
+# INIT_API_ENABLED
+# Enable a programmatic API endpoint for first-boot setup.
+INIT_API_ENABLED =
+
+# INIT_API_TOKEN
+# The bootstrap token required for the initial setup API.
+INIT_API_TOKEN =
+
+
 [security]
 # TRUSTED_HOSTS
 # Comma seperated string containing valid host names for CTFd to respond to. If not specified, 

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -261,6 +261,10 @@ class ServerConfig(object):
     OAUTH_CLIENT_ID: str = empty_str_cast(config_ini["oauth"]["OAUTH_CLIENT_ID"])
     OAUTH_CLIENT_SECRET: str = empty_str_cast(config_ini["oauth"]["OAUTH_CLIENT_SECRET"])
 
+    # === INIT ===
+    INIT_API_ENABLED: bool = process_boolean_str(empty_str_cast(config_ini["init"].get("INIT_API_ENABLED", False), default=False))
+    INIT_API_TOKEN: str = empty_str_cast(config_ini["init"].get("INIT_API_TOKEN", ""))
+
     # === MANAGEMENT ===
     PRESET_ADMIN_NAME: str = empty_str_cast(config_ini["management"].get("PRESET_ADMIN_NAME", "")) if config_ini.has_section("management") else None
     PRESET_ADMIN_EMAIL: str = empty_str_cast(config_ini["management"].get("PRESET_ADMIN_EMAIL", "")) if config_ini.has_section("management") else None

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -48,6 +48,183 @@ from CTFd.utils.user import (
     get_locale,
     is_admin,
 )
+from CTFd.models import Admins, Pages, db
+from CTFd.utils import get_config, set_config
+from CTFd.utils.uploads import upload_file
+from CTFd.utils.email import (
+    DEFAULT_PASSWORD_RESET_BODY,
+    DEFAULT_PASSWORD_RESET_SUBJECT,
+    DEFAULT_SUCCESSFUL_REGISTRATION_EMAIL_BODY,
+    DEFAULT_SUCCESSFUL_REGISTRATION_EMAIL_SUBJECT,
+    DEFAULT_USER_CREATION_EMAIL_BODY,
+    DEFAULT_USER_CREATION_EMAIL_SUBJECT,
+    DEFAULT_VERIFICATION_EMAIL_BODY,
+    DEFAULT_VERIFICATION_EMAIL_SUBJECT,
+)
+from CTFd.constants.config import ConfigTypes
+from CTFd.constants.themes import DEFAULT_THEME
+
+def setup_ctf(args):
+    # General
+    ctf_name = args.get("ctf_name")
+    ctf_description = args.get("ctf_description")
+    user_mode = args.get("user_mode")
+    set_config("ctf_name", ctf_name)
+    set_config("ctf_description", ctf_description)
+    set_config("user_mode", user_mode)
+
+    # Settings
+    challenge_visibility = args.get("challenge_visibility")
+    account_visibility = args.get("account_visibility")
+    score_visibility = args.get("score_visibility")
+    registration_visibility = args.get("registration_visibility")
+    verify_emails = args.get("verify_emails")
+    social_shares = args.get("social_shares")
+    team_size = args.get("team_size")
+
+    # Style
+    ctf_logo = args.get("ctf_logo")
+    if ctf_logo:
+        f = upload_file(file=ctf_logo)
+        set_config("ctf_logo", f.location)
+
+    ctf_small_icon = args.get("ctf_small_icon")
+    if ctf_small_icon:
+        f = upload_file(file=ctf_small_icon)
+        set_config("ctf_small_icon", f.location)
+
+    theme = args.get("ctf_theme", DEFAULT_THEME)
+    set_config("ctf_theme", theme)
+    theme_color = args.get("theme_color")
+    theme_header = get_config("theme_header")
+    if theme_color and bool(theme_header) is False:
+        # Uses {{ and }} to insert curly braces while using the format method
+        css = (
+            '<style id="theme-color">\n'
+            ":root {{--theme-color: {theme_color};}}\n"
+            ".navbar{{background-color: var(--theme-color) !important;}}\n"
+            ".jumbotron{{background-color: var(--theme-color) !important;}}\n"
+            "</style>\n"
+        ).format(theme_color=theme_color)
+        set_config("theme_header", css)
+
+    # DateTime
+    start = args.get("start")
+    end = args.get("end")
+    set_config("start", start)
+    set_config("end", end)
+    set_config("freeze", None)
+
+    # Administration
+    name = args.get("name")
+    email = args.get("email")
+    password = args.get("password")
+
+    admin = Admins(
+        name=name, email=email, password=password, type="admin", hidden=True
+    )
+
+    # Create an empty index page
+    page = Pages(title=ctf_name, route="index", content="", draft=False)
+
+    # Upload banner
+    default_ctf_banner_location = url_for("views.themes", path="img/logo.png")
+    ctf_banner = args.get("ctf_banner")
+    if ctf_banner:
+        f = upload_file(file=ctf_banner, page_id=page.id)
+        default_ctf_banner_location = url_for("views.files", path=f.location)
+        set_config("ctf_banner", f.location)
+
+    # Splice in our banner
+    index = f"""<div class="row">
+<div class="col-md-6 offset-md-3">
+<img class="w-100 mx-auto d-block" style="max-width: 500px;padding: 50px;padding-top: 14vh;" src="{default_ctf_banner_location}" />
+<h3 class="text-center">
+    <p>A cool CTF platform from <a href="https://ctfd.io">ctfd.io</a></p>
+    <p>Follow us on social media:</p>
+    <a href="https://twitter.com/ctfdio"><i class="fab fa-twitter fa-2x" aria-hidden="true"></i></a>&nbsp;
+    <a href="https://facebook.com/ctfdio"><i class="fab fa-facebook fa-2x" aria-hidden="true"></i></a>&nbsp;
+    <a href="https://github.com/ctfd"><i class="fab fa-github fa-2x" aria-hidden="true"></i></a>
+</h3>
+<br>
+<h4 class="text-center">
+    <a href="admin">Click here</a> to login and setup your CTF
+</h4>
+</div>
+</div>"""
+    page.content = index
+
+    # Visibility
+    set_config(ConfigTypes.CHALLENGE_VISIBILITY, challenge_visibility)
+    set_config(ConfigTypes.REGISTRATION_VISIBILITY, registration_visibility)
+    set_config(ConfigTypes.SCORE_VISIBILITY, score_visibility)
+    set_config(ConfigTypes.ACCOUNT_VISIBILITY, account_visibility)
+
+    # Verify emails
+    set_config("verify_emails", verify_emails)
+
+    # Social shares
+    set_config("social_shares", social_shares)
+
+    # Team Size
+    set_config("team_size", team_size)
+
+    set_config("mail_server", None)
+    set_config("mail_port", None)
+    set_config("mail_tls", None)
+    set_config("mail_ssl", None)
+    set_config("mail_username", None)
+    set_config("mail_password", None)
+    set_config("mail_useauth", None)
+
+    # Set up default emails
+    set_config("verification_email_subject", DEFAULT_VERIFICATION_EMAIL_SUBJECT)
+    set_config("verification_email_body", DEFAULT_VERIFICATION_EMAIL_BODY)
+
+    set_config(
+        "successful_registration_email_subject",
+        DEFAULT_SUCCESSFUL_REGISTRATION_EMAIL_SUBJECT,
+    )
+    set_config(
+        "successful_registration_email_body",
+        DEFAULT_SUCCESSFUL_REGISTRATION_EMAIL_BODY,
+    )
+
+    set_config(
+        "user_creation_email_subject", DEFAULT_USER_CREATION_EMAIL_SUBJECT
+    )
+    set_config("user_creation_email_body", DEFAULT_USER_CREATION_EMAIL_BODY)
+
+    set_config("password_reset_subject", DEFAULT_PASSWORD_RESET_SUBJECT)
+    set_config("password_reset_body", DEFAULT_PASSWORD_RESET_BODY)
+
+    set_config(
+        "password_change_alert_subject",
+        "Password Change Confirmation for {ctf_name}",
+    )
+    set_config(
+        "password_change_alert_body",
+        (
+            "Your password for {ctf_name} has been changed.\n\n"
+            "If you didn't request a password change you can reset your password here: {url}"
+        ),
+    )
+
+    set_config("setup", True)
+
+    try:
+        db.session.add(admin)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+
+    try:
+        db.session.add(page)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+
+    return admin
 
 
 def init_cli(app):
@@ -223,6 +400,7 @@ def init_request_processors(app):
                 "views.files",
                 "views.healthcheck",
                 "views.robots",
+                "api.init_setup",
             ):
                 return
             else:
@@ -323,6 +501,8 @@ def init_request_processors(app):
 
     @app.before_request
     def tokens():
+        if request.endpoint == "api.init_setup":
+            return
         token = request.headers.get("Authorization")
         if token and (
             request.mimetype == "application/json"

--- a/CTFd/utils/validators/users.py
+++ b/CTFd/utils/validators/users.py
@@ -1,0 +1,42 @@
+from CTFd.models import Users
+from CTFd.utils import validators
+
+
+def validate_admin_user(name, email, password):
+    errors = []
+    name = name.strip()
+    email = email.strip()
+    password = password.strip()
+
+    name_len = len(name) == 0
+    names = (
+        Users.query.add_columns(Users.name, Users.id)
+        .filter_by(name=name)
+        .first()
+    )
+    emails = (
+        Users.query.add_columns(Users.email, Users.id)
+        .filter_by(email=email)
+        .first()
+    )
+    pass_short = len(password) == 0
+    pass_long = len(password) > 128
+    valid_email = validators.validate_email(email)
+    team_name_email_check = validators.validate_email(name)
+
+    if not valid_email:
+        errors.append("Please enter a valid email address")
+    if names:
+        errors.append("That user name is already taken")
+    if team_name_email_check is True:
+        errors.append("Your user name cannot be an email address")
+    if emails:
+        errors.append("That email has already been used")
+    if pass_short:
+        errors.append("Pick a longer password")
+    if pass_long:
+        errors.append("Pick a shorter password")
+    if name_len:
+        errors.append("Pick a longer user name")
+
+    return errors

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -58,6 +58,7 @@ from CTFd.utils.helpers import get_errors, get_infos, markup
 from CTFd.utils.modes import USERS_MODE
 from CTFd.utils.security.auth import login_user
 from CTFd.utils.security.csrf import generate_nonce
+from CTFd.utils.initialization import setup_ctf
 from CTFd.utils.security.signing import (
     BadSignature,
     BadTimeSignature,
@@ -78,77 +79,10 @@ def setup():
         if not session.get("nonce"):
             session["nonce"] = generate_nonce()
         if request.method == "POST":
-            # General
-            ctf_name = request.form.get("ctf_name")
-            ctf_description = request.form.get("ctf_description")
-            user_mode = request.form.get("user_mode", USERS_MODE)
-            set_config("ctf_name", ctf_name)
-            set_config("ctf_description", ctf_description)
-            set_config("user_mode", user_mode)
-
-            # Settings
-            challenge_visibility = ChallengeVisibilityTypes(
-                request.form.get(
-                    "challenge_visibility", default=ChallengeVisibilityTypes.PRIVATE
-                )
-            )
-            account_visibility = AccountVisibilityTypes(
-                request.form.get(
-                    "account_visibility", default=AccountVisibilityTypes.PUBLIC
-                )
-            )
-            score_visibility = ScoreVisibilityTypes(
-                request.form.get(
-                    "score_visibility", default=ScoreVisibilityTypes.PUBLIC
-                )
-            )
-            registration_visibility = RegistrationVisibilityTypes(
-                request.form.get(
-                    "registration_visibility",
-                    default=RegistrationVisibilityTypes.PUBLIC,
-                )
-            )
-            verify_emails = request.form.get("verify_emails")
-            social_shares = request.form.get("social_shares")
-            team_size = request.form.get("team_size")
-
-            # Style
-            ctf_logo = request.files.get("ctf_logo")
-            if ctf_logo:
-                f = upload_file(file=ctf_logo)
-                set_config("ctf_logo", f.location)
-
-            ctf_small_icon = request.files.get("ctf_small_icon")
-            if ctf_small_icon:
-                f = upload_file(file=ctf_small_icon)
-                set_config("ctf_small_icon", f.location)
-
-            theme = request.form.get("ctf_theme", DEFAULT_THEME)
-            set_config("ctf_theme", theme)
-            theme_color = request.form.get("theme_color")
-            theme_header = get_config("theme_header")
-            if theme_color and bool(theme_header) is False:
-                # Uses {{ and }} to insert curly braces while using the format method
-                css = (
-                    '<style id="theme-color">\n'
-                    ":root {{--theme-color: {theme_color};}}\n"
-                    ".navbar{{background-color: var(--theme-color) !important;}}\n"
-                    ".jumbotron{{background-color: var(--theme-color) !important;}}\n"
-                    "</style>\n"
-                ).format(theme_color=theme_color)
-                set_config("theme_header", css)
-
-            # DateTime
-            start = request.form.get("start")
-            end = request.form.get("end")
-            set_config("start", start)
-            set_config("end", end)
-            set_config("freeze", None)
-
             # Administration
-            name = request.form["name"]
-            email = request.form["email"]
-            password = request.form["password"]
+            name = request.form.get("name", "").strip()
+            email = request.form.get("email", "").strip()
+            password = request.form.get("password", "").strip()
 
             name_len = len(name) == 0
             names = (
@@ -191,109 +125,9 @@ def setup():
                     state=serialize(generate_nonce()),
                 )
 
-            admin = Admins(
-                name=name, email=email, password=password, type="admin", hidden=True
-            )
-
-            # Create an empty index page
-            page = Pages(title=ctf_name, route="index", content="", draft=False)
-
-            # Upload banner
-            default_ctf_banner_location = url_for("views.themes", path="img/logo.png")
-            ctf_banner = request.files.get("ctf_banner")
-            if ctf_banner:
-                f = upload_file(file=ctf_banner, page_id=page.id)
-                default_ctf_banner_location = url_for("views.files", path=f.location)
-                set_config("ctf_banner", f.location)
-
-            # Splice in our banner
-            index = f"""<div class="row">
-    <div class="col-md-6 offset-md-3">
-        <img class="w-100 mx-auto d-block" style="max-width: 500px;padding: 50px;padding-top: 14vh;" src="{default_ctf_banner_location}" />
-        <h3 class="text-center">
-            <p>A cool CTF platform from <a href="https://ctfd.io">ctfd.io</a></p>
-            <p>Follow us on social media:</p>
-            <a href="https://twitter.com/ctfdio"><i class="fab fa-twitter fa-2x" aria-hidden="true"></i></a>&nbsp;
-            <a href="https://facebook.com/ctfdio"><i class="fab fa-facebook fa-2x" aria-hidden="true"></i></a>&nbsp;
-            <a href="https://github.com/ctfd"><i class="fab fa-github fa-2x" aria-hidden="true"></i></a>
-        </h3>
-        <br>
-        <h4 class="text-center">
-            <a href="admin">Click here</a> to login and setup your CTF
-        </h4>
-    </div>
-</div>"""
-            page.content = index
-
-            # Visibility
-            set_config(ConfigTypes.CHALLENGE_VISIBILITY, challenge_visibility)
-            set_config(ConfigTypes.REGISTRATION_VISIBILITY, registration_visibility)
-            set_config(ConfigTypes.SCORE_VISIBILITY, score_visibility)
-            set_config(ConfigTypes.ACCOUNT_VISIBILITY, account_visibility)
-
-            # Verify emails
-            set_config("verify_emails", verify_emails)
-
-            # Social shares
-            set_config("social_shares", social_shares)
-
-            # Team Size
-            set_config("team_size", team_size)
-
-            set_config("mail_server", None)
-            set_config("mail_port", None)
-            set_config("mail_tls", None)
-            set_config("mail_ssl", None)
-            set_config("mail_username", None)
-            set_config("mail_password", None)
-            set_config("mail_useauth", None)
-
-            # Set up default emails
-            set_config("verification_email_subject", DEFAULT_VERIFICATION_EMAIL_SUBJECT)
-            set_config("verification_email_body", DEFAULT_VERIFICATION_EMAIL_BODY)
-
-            set_config(
-                "successful_registration_email_subject",
-                DEFAULT_SUCCESSFUL_REGISTRATION_EMAIL_SUBJECT,
-            )
-            set_config(
-                "successful_registration_email_body",
-                DEFAULT_SUCCESSFUL_REGISTRATION_EMAIL_BODY,
-            )
-
-            set_config(
-                "user_creation_email_subject", DEFAULT_USER_CREATION_EMAIL_SUBJECT
-            )
-            set_config("user_creation_email_body", DEFAULT_USER_CREATION_EMAIL_BODY)
-
-            set_config("password_reset_subject", DEFAULT_PASSWORD_RESET_SUBJECT)
-            set_config("password_reset_body", DEFAULT_PASSWORD_RESET_BODY)
-
-            set_config(
-                "password_change_alert_subject",
-                "Password Change Confirmation for {ctf_name}",
-            )
-            set_config(
-                "password_change_alert_body",
-                (
-                    "Your password for {ctf_name} has been changed.\n\n"
-                    "If you didn't request a password change you can reset your password here: {url}"
-                ),
-            )
-
-            set_config("setup", True)
-
-            try:
-                db.session.add(admin)
-                db.session.commit()
-            except IntegrityError:
-                db.session.rollback()
-
-            try:
-                db.session.add(page)
-                db.session.commit()
-            except IntegrityError:
-                db.session.rollback()
+            args = dict(request.form)
+            args.update(request.files)
+            admin = setup_ctf(args=args)
 
             login_user(admin)
 

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -59,6 +59,7 @@ from CTFd.utils.modes import USERS_MODE
 from CTFd.utils.security.auth import login_user
 from CTFd.utils.security.csrf import generate_nonce
 from CTFd.utils.initialization import setup_ctf
+from CTFd.utils.validators.users import validate_admin_user
 from CTFd.utils.security.signing import (
     BadSignature,
     BadTimeSignature,
@@ -84,36 +85,7 @@ def setup():
             email = request.form.get("email", "").strip()
             password = request.form.get("password", "").strip()
 
-            name_len = len(name) == 0
-            names = (
-                Users.query.add_columns(Users.name, Users.id)
-                .filter_by(name=name)
-                .first()
-            )
-            emails = (
-                Users.query.add_columns(Users.email, Users.id)
-                .filter_by(email=email)
-                .first()
-            )
-            pass_short = len(password) == 0
-            pass_long = len(password) > 128
-            valid_email = validators.validate_email(request.form["email"])
-            team_name_email_check = validators.validate_email(name)
-
-            if not valid_email:
-                errors.append("Please enter a valid email address")
-            if names:
-                errors.append("That user name is already taken")
-            if team_name_email_check is True:
-                errors.append("Your user name cannot be an email address")
-            if emails:
-                errors.append("That email has already been used")
-            if pass_short:
-                errors.append("Pick a longer password")
-            if pass_long:
-                errors.append("Pick a shorter password")
-            if name_len:
-                errors.append("Pick a longer user name")
+            errors.extend(validate_admin_user(name=name, email=email, password=password))
 
             if len(errors) > 0:
                 return render_template(

--- a/tests/api/v1/test_init.py
+++ b/tests/api/v1/test_init.py
@@ -1,0 +1,79 @@
+from CTFd.utils import get_config
+from CTFd.utils.config import is_setup
+from tests.helpers import create_ctfd, destroy_ctfd, gen_user
+
+
+def test_api_setup_post_not_enabled():
+    """
+    Test that `POST /api/v1/init/setup` fails if the API is not enabled
+    """
+    app = create_ctfd(setup=False)
+    with app.app_context():
+        with app.test_client() as client:
+            r = client.post("/api/v1/init/setup")
+            assert r.status_code == 403
+    destroy_ctfd(app)
+
+
+def test_api_setup_post_invalid_token():
+    """
+    Test that `POST /api/v1/init/setup` fails with an invalid token
+    """
+    app = create_ctfd(setup=False)
+    with app.app_context():
+        app.config["INIT_API_ENABLED"] = True
+        app.config["INIT_API_TOKEN"] = "valid_token"
+        with app.test_client() as client:
+            r = client.post(
+                "/api/v1/init/setup",
+                headers={"Authorization": "Bearer invalid_token"},
+                json={},
+            )
+            assert r.status_code == 401
+    destroy_ctfd(app)
+
+
+def test_api_setup_post_already_configured():
+    """
+    Test that `POST /api/v1/init/setup` fails if CTFd is already configured
+    """
+    app = create_ctfd(setup=True)
+    with app.app_context():
+        app.config["INIT_API_ENABLED"] = True
+        app.config["INIT_API_TOKEN"] = "valid_token"
+        with app.test_client() as client:
+            r = client.post(
+                "/api/v1/init/setup",
+                headers={"Authorization": "Bearer valid_token"},
+                json={},
+            )
+            assert r.status_code == 409
+    destroy_ctfd(app)
+
+
+def test_api_setup_post_success():
+    """
+    Test that `POST /api/v1/init/setup` succeeds with valid data
+    """
+    app = create_ctfd(setup=False)
+    with app.app_context():
+        app.config["INIT_API_ENABLED"] = True
+        app.config["INIT_API_TOKEN"] = "valid_token"
+        with app.test_client() as client:
+            data = {
+                "ctf_name": "Test CTF",
+                "ctf_description": "This is a test CTF",
+                "user_mode": "users",
+                "name": "admin",
+                "email": "admin@test.com",
+                "password": "password",
+            }
+            r = client.post(
+                "/api/v1/init/setup",
+                headers={"Authorization": "Bearer valid_token"},
+                json=data,
+            )
+            assert r.status_code == 200
+            assert get_config("ctf_name") == "Test CTF"
+            assert is_setup() is True
+    destroy_ctfd(app)


### PR DESCRIPTION
Implements the feature described in #2816.

This change adds a new, opt-in JSON API endpoint to perform initial setup in a secure, idempotent, and well-documented way. This is useful for automating CTFd deployments.

The new endpoint is `POST /api/v1/init/setup`. It is disabled by default and can be enabled by setting `CTFD_INIT_API_ENABLED=true` and providing a `CTFD_INIT_API_TOKEN`.

The setup logic has been refactored into a shared `setup_ctf` function to be used by both the new API and the existing web-based setup.