### PR TITLE
refactor: use dataclasses for user and team attrs

### DIFF
--- a/CTFd/constants/teams.py
+++ b/CTFd/constants/teams.py
@@ -1,26 +1,25 @@
-from collections import namedtuple
+from dataclasses import dataclass, fields
+from typing import Any
 
-# TODO: CTFd 4.0. Consider changing to a dataclass
-TeamAttrsFields = [
-    "id",
-    "oauth_id",
-    "name",
-    "email",
-    "secret",
-    "website",
-    "affiliation",
-    "country",
-    "bracket_id",
-    "hidden",
-    "banned",
-    "captain_id",
-    "created",
-]
-TeamAttrs = namedtuple(
-    "TeamAttrs",
-    TeamAttrsFields,
-    defaults=(None,) * len(TeamAttrsFields),
-)
+
+@dataclass(frozen=True)
+class TeamAttrs:
+    id: Any = None
+    oauth_id: Any = None
+    name: Any = None
+    email: Any = None
+    secret: Any = None
+    website: Any = None
+    affiliation: Any = None
+    country: Any = None
+    bracket_id: Any = None
+    hidden: Any = None
+    banned: Any = None
+    captain_id: Any = None
+    created: Any = None
+
+
+TeamAttrsFields = [f.name for f in fields(TeamAttrs)]
 
 
 class _TeamAttrsWrapper:

--- a/CTFd/constants/users.py
+++ b/CTFd/constants/users.py
@@ -1,28 +1,29 @@
-from collections import namedtuple
+from dataclasses import dataclass, fields
+from typing import Any
 
-# TODO: CTFd 4.0. Consider changing to a dataclass
-UserAttrsFields = [
-    "id",
-    "oauth_id",
-    "name",
-    "email",
-    "type",
-    "secret",
-    "website",
-    "affiliation",
-    "country",
-    "bracket_id",
-    "hidden",
-    "banned",
-    "verified",
-    "language",
-    "team_id",
-    "created",
-    "change_password",
-]
-UserAttrs = namedtuple(
-    "UserAttrs", UserAttrsFields, defaults=(None,) * len(UserAttrsFields)
-)
+
+@dataclass(frozen=True)
+class UserAttrs:
+    id: Any = None
+    oauth_id: Any = None
+    name: Any = None
+    email: Any = None
+    type: Any = None
+    secret: Any = None
+    website: Any = None
+    affiliation: Any = None
+    country: Any = None
+    bracket_id: Any = None
+    hidden: Any = None
+    banned: Any = None
+    verified: Any = None
+    language: Any = None
+    team_id: Any = None
+    created: Any = None
+    change_password: Any = None
+
+
+UserAttrsFields = [f.name for f in fields(UserAttrs)]
 
 
 class _UserAttrsWrapper:

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -7,8 +7,8 @@ from flask import redirect, request, session, url_for
 
 from CTFd.cache import cache, clear_user_session
 from CTFd.constants.languages import Languages
-from CTFd.constants.teams import TeamAttrs
-from CTFd.constants.users import UserAttrs
+from CTFd.constants.teams import TeamAttrs, TeamAttrsFields
+from CTFd.constants.users import UserAttrs, UserAttrsFields
 from CTFd.models import Fails, Teams, Tracking, Users, db
 from CTFd.utils import get_config
 from CTFd.utils.security.auth import logout_user
@@ -50,9 +50,7 @@ def get_current_user_attrs():
 def get_user_attrs(user_id):
     user = Users.query.filter_by(id=user_id).first()
     if user:
-        d = {}
-        for field in UserAttrs._fields:
-            d[field] = getattr(user, field)
+        d = {field: getattr(user, field) for field in UserAttrsFields}
         return UserAttrs(**d)
     return None
 
@@ -113,9 +111,7 @@ def get_current_team_attrs():
 def get_team_attrs(team_id):
     team = Teams.query.filter_by(id=team_id).first()
     if team:
-        d = {}
-        for field in TeamAttrs._fields:
-            d[field] = getattr(team, field)
+        d = {field: getattr(team, field) for field in TeamAttrsFields}
         return TeamAttrs(**d)
     return None
 


### PR DESCRIPTION
## Summary
- replace namedtuple-based user and team attribute containers with dataclasses
- update attribute helpers to use new dataclass field lists

## Testing
- `make lint` *(fails: Invalid rule code provided to `# noqa` at CTFd/config.py)*
- `pytest --ignore-glob="**/node_modules/" --ignore=node_modules/ -W ignore::sqlalchemy.exc.SADeprecationWarning -W ignore::sqlalchemy.exc.SAWarning` *(fails: ModuleNotFoundError: No module named 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_68ae145849b88321a66c9fe58acf5418